### PR TITLE
removed first empty line

### DIFF
--- a/woocommerce-product-search-manufacturer.php
+++ b/woocommerce-product-search-manufacturer.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * woocommerce-product-search-manufacturer.php
@@ -67,3 +66,4 @@ class WooCommerce_Product_Search_Manufacturer {
 }
 
 WooCommerce_Product_Search_Manufacturer::init();
+


### PR DESCRIPTION
It generates an admin notice on plugin activation, that an unexpected output of 1 character has been produced